### PR TITLE
Typo Error in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Hi my name is Elle
 ```
 
 However, there is a problem with the code. When invoking
-`greeAfterNamechange(changeName, newName)` with the `changeName` instance method
+`greetAfterNameChange(changeName, newName)` with the `changeName` instance method
 on the newly instantiated user, the context of the `changeName` function is lost
 so there will be an error thrown when running the __index.js__ file.
 

--- a/index.js
+++ b/index.js
@@ -10,3 +10,4 @@ function greetAfterNameChange(changeName, newName) {
 
 greetAfterNameChange(michelle.changeName, 'Elle');
   // should print out: Hi my name is Elle
+  


### PR DESCRIPTION
In the Readme.md file at Ln 43, Col 6 as well as at ln 43, Col 16. The function name `greetAfterNameChange` used to be `greeAfterNamechange`.

> Side note: this is my first time "contributing" to a public repository so if I made any mistakes in creating this pull request please let me know if that is possible 